### PR TITLE
Tm1 v12 ga release testing

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -843,7 +843,7 @@ class CellService(ObjectService):
               deactivate_transaction_log: bool = False, reactivate_transaction_log: bool = False,
               sandbox_name: str = None, use_ti: bool = False, use_blob: bool = False, use_changeset: bool = False,
               precision: int = None, skip_non_updateable: bool = False, measure_dimension_elements: Dict = None,
-              remove_blob: bool = True, allow_spread: bool=False, **kwargs) -> Optional[str]:
+              remove_blob: bool = True, allow_spread: bool = False, **kwargs) -> Optional[str]:
         """ Write values to a cube
 
         Same signature as `write_values` method, but faster since it uses `write_values_through_cellset`
@@ -1039,7 +1039,7 @@ class CellService(ObjectService):
     @require_pandas
     def write_through_blob(self, cube_name: str, cellset_as_dict: dict, increment: bool = False,
                            sandbox_name: str = None, skip_non_updateable: bool = False,
-                           remove_blob=True, dimensions: str = None, allow_spread: bool=False, **kwargs):
+                           remove_blob=True, dimensions: str = None, allow_spread: bool = False, **kwargs):
         """
         Writes data back to TM1 via an unbound TI process having an uploaded CSV as data source
         :param cube_name: str
@@ -2928,7 +2928,8 @@ class CellService(ObjectService):
             "/Cellsets('{}')?$expand=Cells($select=Value{})",
             cellset_id,
             f";$filter={filter_cells}" if filter_cells else "")
-        url = add_url_parameters(url, **{"!sandbox": sandbox_name})
+        if sandbox_name:
+            url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         response = self._rest.GET(url=url, **kwargs)
 
         if not use_compact_json:

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -19,7 +19,7 @@ from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils import CaseAndSpaceInsensitiveDict, format_url, CaseAndSpaceInsensitiveSet, require_admin, \
     dimension_hierarchy_element_tuple_from_unique_name, require_pandas
-from TM1py.Utils import build_element_unique_names, CaseAndSpaceInsensitiveTuplesDict
+from TM1py.Utils import build_element_unique_names, CaseAndSpaceInsensitiveTuplesDict, verify_version
 from itertools import islice
 from collections import OrderedDict
 
@@ -184,22 +184,37 @@ class ElementService(ObjectService):
             for calculated_name, level_name in levels_dict.items():
                 depth += 1
                 name_or_attribute = f"Properties('{parent_attribute}')" if parent_attribute else "NAME"
-                member = f"""
-                MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
-                AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}PROPERTIES('{name_or_attribute}')
-                """
+                if not verify_version(required_version='12', version=self.version):
+                    member = f"""
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
+                    AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}{name_or_attribute}
+                    """
+                else:
+                    member = f"""
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
+                    AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}PROPERTIES('{name_or_attribute}')
+                    """
                 calculated_members_definition.append(member)
 
                 parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}]")
 
                 if not skip_weights:
-                    member_weight = f"""
-                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]
-                    AS IIF(
-                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT') = '',
-                    0,
-                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT'))
-                    """
+                    if not verify_version(required_version='12', version=self.version):
+                        member_weight = f"""
+                        MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight] 
+                        AS IIF(
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (depth - 1)}Properties('MEMBER_WEIGHT') = '',
+                        0,
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (depth - 1)}Properties('MEMBER_WEIGHT'))
+                        """
+                    else:
+                        member_weight = f"""
+                        MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]
+                        AS IIF(
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT') = '',
+                        0,
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT'))
+                        """
                     calculated_members_definition.append(member_weight)
 
                     weight_members.append(

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -20,7 +20,8 @@ from TM1py.Services.RestService import RestService
 from TM1py.Utils import CaseAndSpaceInsensitiveDict, format_url, CaseAndSpaceInsensitiveSet, require_admin, \
     dimension_hierarchy_element_tuple_from_unique_name, require_pandas
 from TM1py.Utils import build_element_unique_names, CaseAndSpaceInsensitiveTuplesDict
-
+from itertools import islice
+from collections import OrderedDict
 
 class MDXDrillMethod(Enum):
     TM1DRILLDOWNMEMBER = 1
@@ -154,45 +155,56 @@ class ElementService(ObjectService):
 
         calculated_members_definition = list()
         calculated_members_selection = list()
+        levels_dict = {}
         if not skip_parents:
             levels = self.get_levels_count(dimension_name, hierarchy_name)
 
-            # potential custom parent names
+            #Generic Level names can't be used directly as a Calculated Member name as they conflict with an internal name
+            #Therefore, we create a map that relates the level name to the calculated member name L000 = level000
             if not level_names:
                 level_names = self.get_level_names(dimension_name, hierarchy_name, descending=True)
                 level_calculated_member_names = []
-                for level in range(0, levels, 1):
-                    level_calculated_member_names.append(f"L{str(level).zfill(3)}")
-                level_dict = dict(zip(level_calculated_member_names, level_names))
 
+                #Create a map of MDX Calculated Member Names and Desired Pandas Names
+                for level in reversed(range(levels)):
+                    level_calculated_member_names.append(f"L{str(level).zfill(3)}")
+                all_level_dict = OrderedDict(zip(level_calculated_member_names, level_names))
+
+            #if a specific parent names are provided the calculated member name is = to the data frame column name
+            else:
+                all_level_dict = OrderedDict(zip(level_names, level_names))
+
+            # Remove the highest level (leafs) to create proper MDX calculated members
+            levels_dict = {k: all_level_dict[k] for k in list(all_level_dict)[1:]}
+
+            #iterate the map of levels to create an MDX calculation and a related column axis definition
             parent_members = list()
             weight_members = list()
-            for parent in range(1, levels, 1):
+            depth = 0
+            for calculated_name, level_name in levels_dict.items():
+                depth += 1
                 name_or_attribute = f"Properties('{parent_attribute}')" if parent_attribute else "NAME"
                 member = f"""
-                MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[L{str(parent).zfill(3)}] 
-                AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * parent}PROPERTIES('{name_or_attribute}')
+                MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
+                AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}PROPERTIES('{name_or_attribute}')
                 """
                 calculated_members_definition.append(member)
 
-                parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[L{str(parent).zfill(3)}]")
-                # AS IIF(
-                # [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT') = '',
-                # 0,
-                # [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT'))
+                parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}]")
 
                 if not skip_weights:
                     member_weight = f"""
-                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}_Weight]
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]
                     AS IIF(
-                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT') = '',
+                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT') = '',
                     0,
-                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT'))
+                    [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT'))
                     """
                     calculated_members_definition.append(member_weight)
 
                     weight_members.append(
-                        f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}_Weight]")
+                        f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]")
+
             calculated_members_selection.extend(weight_members)
             calculated_members_selection.extend(parent_members)
 
@@ -228,14 +240,16 @@ class ElementService(ObjectService):
         """
 
         cell_service = self._get_cell_service()
+
         # responses are similar but not equivalent. Therefor only use execute_mdx_dataframe when use_blob=True
         if use_blob:
             df_data = cell_service.execute_mdx_dataframe(mdx, shaped=True, use_blob=True, **kwargs)
         else:
             df_data = cell_service.execute_mdx_dataframe_shaped(mdx, **kwargs)
 
-        # rename level names to conform sto strandard levels "1" -> "level0001"
-        df_data.rename(columns=level_dict, inplace=True)
+        if levels_dict:
+            # rename level names to conform sto strandard levels "1" -> "level0001"
+            df_data.rename(columns=levels_dict, inplace=True)
 
         #format weights
         # Find columns with certain names
@@ -258,7 +272,8 @@ class ElementService(ObjectService):
             level_names = level_names[1:]
             # iterative approach
             for _ in level_names:
-                rows_to_shift = df_data[df_data[level_names[-1]] == ''].index
+
+                rows_to_shift = df_data[df_data[level_names[-1]].isin(['', None])].index
                 if rows_to_shift.empty:
                     break
                 df_data.iloc[rows_to_shift, -len(level_names):] = df_data.iloc[rows_to_shift, -len(level_names):].shift(

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -160,22 +160,30 @@ class ElementService(ObjectService):
             # potential custom parent names
             if not level_names:
                 level_names = self.get_level_names(dimension_name, hierarchy_name, descending=True)
+                level_calculated_member_names = []
+                for level in range(0, levels, 1):
+                    level_calculated_member_names.append(f"L{str(level).zfill(3)}")
+                level_dict = dict(zip(level_calculated_member_names, level_names))
 
             parent_members = list()
             weight_members = list()
             for parent in range(1, levels, 1):
-                name_or_attribute = f"Properties('{parent_attribute}')" if parent_attribute else "Name"
+                name_or_attribute = f"Properties('{parent_attribute}')" if parent_attribute else "NAME"
                 member = f"""
-                MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}] 
-                AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * parent}{name_or_attribute}
+                MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[L{str(parent).zfill(3)}] 
+                AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * parent}PROPERTIES('{name_or_attribute}')
                 """
                 calculated_members_definition.append(member)
 
-                parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}]")
+                parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[L{str(parent).zfill(3)}]")
+                # AS IIF(
+                # [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT') = '',
+                # 0,
+                # [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT'))
 
                 if not skip_weights:
                     member_weight = f"""
-                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}_Weight] 
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_names[parent]}_Weight]
                     AS IIF(
                     [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (parent - 1)}Properties('MEMBER_WEIGHT') = '',
                     0,
@@ -197,7 +205,11 @@ class ElementService(ObjectService):
                 in attributes) + "}"
 
         if calculated_members_selection:
-            column_selection = column_selection + " + {" + ",".join(calculated_members_selection) + "}"
+            if column_selection == "{}":
+                column_selection = "{" + ",".join(calculated_members_selection) + "}"
+            else:
+                column_selection = column_selection + " + {" + ",".join(calculated_members_selection) + "}"
+
         elements = ",".join(
             member["UniqueName"]
             for member
@@ -221,6 +233,17 @@ class ElementService(ObjectService):
             df_data = cell_service.execute_mdx_dataframe(mdx, shaped=True, use_blob=True, **kwargs)
         else:
             df_data = cell_service.execute_mdx_dataframe_shaped(mdx, **kwargs)
+
+        # rename level names to conform sto strandard levels "1" -> "level0001"
+        df_data.rename(columns=level_dict, inplace=True)
+
+        #format weights
+        # Find columns with certain names
+        cols_to_format = [col for col in df_data.columns if '_Weight' in col]
+
+        # Format the columns
+        df_data[cols_to_format] = df_data[cols_to_format].apply(pd.to_numeric)
+        df_data[cols_to_format] = df_data[cols_to_format].applymap(lambda x: '{:.6f}'.format(x))
 
         # override columns. hierarchy name with dimension and prefix attributes
         column_renaming = dict()
@@ -637,11 +660,11 @@ class ElementService(ObjectService):
         if isinstance(attribute_value, str):
             mdx = (
                 f"{{FILTER({{TM1SUBSETALL([{dimension_name}].[{hierarchy_name}])}},"
-                f"[{dimension_name}].[{hierarchy_name}].[{attribute_name}] = \"{attribute_value}\")}}")
+                f"[{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\") = \"{attribute_value}\")}}")
         else:
             mdx = (
                 f"{{FILTER({{TM1SUBSETALL([{dimension_name}].[{hierarchy_name}])}},"
-                f"[{dimension_name}].[{hierarchy_name}].[{attribute_name}] = {attribute_value})}}")
+                f"STRTOVALUE([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\")) = {attribute_value})}}")
 
         elems = self.execute_set_mdx(
             mdx=mdx,
@@ -948,7 +971,7 @@ class ElementService(ObjectService):
         url = format_url("/ExecuteMDXSetExpression?$select=Cardinality")
         payload = {"MDX": mdx}
         response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False))
-        return response.json()['Cardinality']
+        return (response.json()).get('Cardinality')
 
     @staticmethod
     def _build_drill_intersection_mdx(dimension_name: str, hierarchy_name: str, first_element_name: str,
@@ -1024,7 +1047,17 @@ class ElementService(ObjectService):
                 if not self.hierarchy_exists(dimension_name, hierarchy_name):
                     raise TM1pyException(f"Hierarchy '{hierarchy_name}' does not exist in dimension '{dimension_name}'")
 
-                # case element doesn't exist
+                # case element or ancestor doesn't exist
+                return False
+
+        if method.upper() == "TM1DRILLDOWNMEMBER":
+            if not self.exists(dimension_name, hierarchy_name, element_name):
+
+                # case dimension or hierarchy doesn't exist
+                if not self.hierarchy_exists(dimension_name, hierarchy_name):
+                    raise TM1pyException(f"Hierarchy '{hierarchy_name}' does not exist in dimension '{dimension_name}'")
+
+                # case element or ancestor doesn't exist
                 return False
 
         mdx = self._build_drill_intersection_mdx(

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -664,7 +664,9 @@ class ElementService(ObjectService):
         else:
             mdx = (
                 f"{{FILTER({{TM1SUBSETALL([{dimension_name}].[{hierarchy_name}])}},"
-                f"STRTOVALUE([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\")) = {attribute_value})}}")
+                f"(IIF([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\")=\"\", 0.0," 
+                f"STRTOVALUE([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\"))) = 1))}}"
+            )
 
         elems = self.execute_set_mdx(
             mdx=mdx,

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -22,7 +22,6 @@ from urllib3._collections import HTTPHeaderDict
 from TM1py.Exceptions.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException
 from TM1py.Utils import case_and_space_insensitive_equals, CaseAndSpaceInsensitiveSet, HTTPAdapterWithSocketOptions, \
     decohints
-from Utils import verify_version
 
 try:
     from requests_negotiate_sspi import HttpNegotiateAuth
@@ -526,7 +525,7 @@ class RestService:
                                             json=payload)
                     self.verify_response(response)
                     if 'TM1SessionId' not in self._s.cookies:
-                        warnings.warn(f"TM1SessionId has failed to be added to the session cookies, future requests "
+                        raise TM1pyException(f"TM1SessionId has failed to be added to the session cookies, future requests "
                                       "using this TM1Service instance will fail due to authentication. "
                                       "Check the tm1-gateway domain settings are correct "
                                       "in the container orchestrator ")

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -876,6 +876,10 @@ def extract_compact_json_cellset(context: str, response: Dict, return_as_dict: b
     if len(props) == 1:
         return [value[0] for value in cells_data]
 
+    if props == ['Ordinal', 'Value']:
+        return [value[1] for value in cells_data]
+
+
     return cells_data
 
 

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 from enum import Enum, unique
 from io import StringIO
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator, Union, Callable
-
 import requests
 from mdxpy import MdxBuilder, Member
 from requests.adapters import HTTPAdapter
@@ -93,6 +92,7 @@ def require_pandas(func):
     return wrapper
 
 
+
 def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=False) -> List:
     from TM1py.Objects import Server
     """ Ask Adminhost for TM1 Servers
@@ -106,7 +106,7 @@ def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=Fal
         conn = http_client.HTTPConnection(adminhost, port or 5895)
     else:
         conn = http_client.HTTPSConnection(adminhost, port or 5898, context=ssl._create_unverified_context())
-    request = '/Servers'
+    request = 'api/v1/Servers'
     conn.request('GET', request, body='')
     response = conn.getresponse().read().decode('utf-8')
     response_as_dict = json.loads(response)

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -222,7 +222,7 @@ def abbreviate_mdx(mdx: str, size=100) -> str:
 
 
 def integerize_version(version: str, precision: int = 4) -> int:
-    return int(version[:precision].replace(".", ""))
+    return int(version[:precision].replace(".", "").ljust(precision, "0"))
 
 
 def verify_version(required_version: str, version: str) -> bool:

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -106,7 +106,7 @@ def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=Fal
         conn = http_client.HTTPConnection(adminhost, port or 5895)
     else:
         conn = http_client.HTTPSConnection(adminhost, port or 5898, context=ssl._create_unverified_context())
-    request = 'api/v1/Servers'
+    request = '/api/v1/Servers'
     conn.request('GET', request, body='')
     response = conn.getresponse().read().decode('utf-8')
     response_as_dict = json.loads(response)

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -3995,7 +3995,7 @@ class TestCellService(unittest.TestCase):
             cube_name=self.cube_with_rules_name,
             elements=["Element1", "Element1", "Element1"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_shallow_depth_iterable(self):
         shallow_depth = 1
@@ -4004,7 +4004,7 @@ class TestCellService(unittest.TestCase):
             elements=["Element3", "Element1", "Element1"],
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
 
         self.assertNotIn("Components", components)
@@ -4016,7 +4016,7 @@ class TestCellService(unittest.TestCase):
             elements=["Element3", "Element1", "Element1"],
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
         for _ in range(shallow_depth - 1):
             components = components[0]["Components"]
@@ -4029,14 +4029,14 @@ class TestCellService(unittest.TestCase):
             elements=["Element1", "Element1", "Element1"],
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_no_depth_string(self):
         result = self.tm1.cells.trace_cell_calculation(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_shallow_depth_string(self):
         shallow_depth = 2
@@ -4046,7 +4046,7 @@ class TestCellService(unittest.TestCase):
             elements="Element3,Element1,Element1",
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
         for _ in range(shallow_depth - 1):
             components = components[0]["Components"]
@@ -4059,7 +4059,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             depth=25)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4067,7 +4067,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string_hierarchy(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4077,7 +4077,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4087,14 +4087,14 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_feeders_string(self):
         result = self.tm1.cells.trace_cell_feeders(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4102,7 +4102,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string_hierarchy(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4112,7 +4112,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4122,14 +4122,14 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_check_feeders_string(self):
         result = self.tm1.cells.check_cell_feeders(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4137,7 +4137,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string_hierarchy(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4147,7 +4147,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4157,7 +4157,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     # Delete Cube and Dimensions
     @classmethod

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -2661,6 +2661,9 @@ class TestCellService(unittest.TestCase):
             'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
             'Attr1': {0: 'TM1py'},
             'Value': {0: 1.0}}
+
+
+
         self.assertEqual(expected, df.to_dict())
 
     @skip_if_no_pandas
@@ -2702,15 +2705,16 @@ class TestCellService(unittest.TestCase):
 
         df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, use_iterative_json=True)
 
-        expected = {
+        df_test = pd.DataFrame({
             'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
             'Attr1': {0: 'TM1py'},
             'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
             'Attr2': {0: '2'},
             'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
             'Attr3': {0: '3'},
-            'Value': {0: 1.0}}
-        self.assertEqual(expected, df.to_dict())
+            'Value': {0: 1.0}})
+
+        self.assertTrue(df_test.equals(df))
 
     @skip_if_no_pandas
     def test_execute_mdx_dataframe_include_attributes_iter_json_no_attributes(self):
@@ -3470,17 +3474,17 @@ class TestCellService(unittest.TestCase):
             dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[0],
-                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(10).to_mdx()))
         view.add_row(
             dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[1],
-                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10).to_mdx()))
         view.add_column(
             dimension_name=self.dimension_names[2],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[2],
-                expression='{ HEAD ( {[' + self.dimension_names[2] + '].Members}, 10 ) }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(10).to_mdx()))
         self.tm1.cubes.views.update_or_create(view, private=False)
 
         pivot = self.tm1.cubes.cells.execute_view_dataframe_pivot(
@@ -3500,17 +3504,17 @@ class TestCellService(unittest.TestCase):
             dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[0],
-                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(10).to_mdx()))
         view.add_column(
             dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[1],
-                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10).to_mdx()))
         view.add_column(
             dimension_name=self.dimension_names[2],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[2],
-                expression='{ HEAD ( {[' + self.dimension_names[2] + '].Members}, 10 ) }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(10).to_mdx()))
         self.tm1.cubes.views.update_or_create(
             view=view,
             private=False)
@@ -3528,16 +3532,21 @@ class TestCellService(unittest.TestCase):
             view_name=view_name,
             suppress_empty_columns=False,
             suppress_empty_rows=False)
+
         view.add_row(
             dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[0],
-                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(10).to_mdx()
+            )
+        )
         view.add_column(
             dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
                 dimension_name=self.dimension_names[1],
-                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
+                expression=MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10).to_mdx()
+            )
+        )
         view.add_title(
             dimension_name=self.dimension_names[2],
             selection="Element 1",
@@ -3793,6 +3802,8 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(value, None)
 
     @skip_if_insufficient_version(version="11.7")
+    @skip_if_deprecated_in_version(version="12")
+    # skip if version 12 as invalid element names do not raise an exception
     def test_clear_invalid_element_name(self):
 
         with self.assertRaises(TM1pyException) as e:
@@ -3812,14 +3823,11 @@ class TestCellService(unittest.TestCase):
         with self.assertRaises(TM1pyException) as e:
             mdx = f"""
             SELECT
-            {{[{self.dimension_names[0]}].[NotExistingElement]}} ON 0
+            {{[{self.dimension_names[0]}].MissingSquareBracket]}} ON 0
             FROM [{self.cube_name}]
             """
             self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
-        self.assertIn(
-            '\\"NotExistingElement\\" :',
-            str(e.exception.message))
 
     def test_clear_with_mdx_unsupported_version(self):
 
@@ -3841,6 +3849,8 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(
             str(e.exception),
             str(TM1pyVersionException(function="clear_with_mdx", required_version="11.7")))
+
+        self.tm1._tm1_rest.set_version()
 
     def test_execute_mdx_with_skip(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -11,7 +11,7 @@ from TM1py.Objects import (AnonymousSubset, Cube, Dimension, Element,
                            ElementAttribute, Hierarchy, MDXView, NativeView)
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict, \
-    CaseAndSpaceInsensitiveTuplesDict
+    CaseAndSpaceInsensitiveTuplesDict, verify_version
 from .Utils import skip_if_insufficient_version, skip_if_no_pandas, skip_if_deprecated_in_version
 
 try:
@@ -650,7 +650,12 @@ class TestCellService(unittest.TestCase):
         query.add_member_tuple_to_columns(
             f"[{self.dimension_names[0]}].[element2]",
             f"[}}ElementAttributes_{self.dimension_names[0]}].[Attr3]")
-        self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), ['Text 1', 1, 2, "", None, None])
+        values = self.tm1.cells.execute_mdx_values(mdx=query.to_mdx())
+
+        if verify_version(required_version="12",version=self.tm1.version):
+            self.assertEqual(values, ['Text 1', 1, 2, "", 0, 0])
+        else:
+            self.assertEqual(values, ['Text 1', 1, 2, "", None, None])
 
     def test_write_through_unbound_process_to_consolidation(self):
         cells = dict()

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -1463,6 +1463,8 @@ class TestCellService(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
+    @skip_if_deprecated_in_version(version="12")
+    #v12 does not support empty row sets
     def test_execute_mdx_with_empty_rows(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -1491,6 +1493,7 @@ class TestCellService(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
+    @skip_if_deprecated_in_version(version="12")
     def test_execute_mdx_with_empty_columns(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -29,10 +29,10 @@ class TestProcessService(unittest.TestCase):
                       datasource_ascii_header_records=2,
                       datasource_ascii_quote_character='^',
                       datasource_ascii_thousand_separator='~',
-                      prolog_procedure="sTestProlog = 'test prolog procedure'",
-                      metadata_procedure="sTestMeta = 'test metadata procedure'",
-                      data_procedure="sTestData =  'test data procedure'",
-                      epilog_procedure="sTestEpilog = 'test epilog procedure'",
+                      prolog_procedure="sTestProlog = 'test prolog procedure';",
+                      metadata_procedure="sTestMeta = 'test metadata procedure';",
+                      data_procedure="sTestData =  'test data procedure';",
+                      epilog_procedure="sTestEpilog = 'test epilog procedure';",
                       datasource_data_source_name_for_server=r'C:\Data\file.csv',
                       datasource_data_source_name_for_client=r'C:\Data\file.csv')
     p_ascii.add_variable('v_1', 'Numeric')

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -38,35 +38,35 @@ class TestUtilsMethods(unittest.TestCase):
     def test_integerize_version(self):
         version = "11.0.00000.918"
         integerized_version = integerize_version(version)
-        self.assertEqual(110, integerized_version)
+        self.assertEqual(1100, integerized_version)
 
         version = "11.0.00100.927-0"
         integerized_version = integerize_version(version)
-        self.assertEqual(110, integerized_version)
+        self.assertEqual(1100, integerized_version)
 
         version = "11.1.00004.2"
         integerized_version = integerize_version(version)
-        self.assertEqual(111, integerized_version)
+        self.assertEqual(1110, integerized_version)
 
         version = "11.2.00000.27"
         integerized_version = integerize_version(version)
-        self.assertEqual(112, integerized_version)
+        self.assertEqual(1120, integerized_version)
 
         version = "11.3.00003.1"
         integerized_version = integerize_version(version)
-        self.assertEqual(113, integerized_version)
+        self.assertEqual(1130, integerized_version)
 
         version = "11.4.00003.8"
         integerized_version = integerize_version(version)
-        self.assertEqual(114, integerized_version)
+        self.assertEqual(1140, integerized_version)
 
         version = "11.7.00002.1"
         integerized_version = integerize_version(version)
-        self.assertEqual(117, integerized_version)
+        self.assertEqual(1170, integerized_version)
 
         version = "11.8.00000.33"
         integerized_version = integerize_version(version)
-        self.assertEqual(118, integerized_version)
+        self.assertEqual(1180, integerized_version)
 
     def test_verify_version_true(self):
         required_version = "11.7.00002.1"


### PR DESCRIPTION
Changes for GA Release Support

* Small changes to URL construction to prevent trailing &
* Significant changes to correct support for get_elements_datafram function
    * Level naming conflicts
    * Attribute property references
* Changes to MDX construction to ensure the use of PROPERTIES
* Fixed issues with ELISANC method to check for missing elements before execution
* New method to extract session ID to bypass issues with domain definitions in CP4D
* Fixed issue with getting servers from admin host
* Updated the methods to used to turn version numbers into integers and related tests
* Fixed problems introduced by new Compact JSON format
* Fixed trace and check tests to use the new odata tag
* Fixed issues with clear via MDX methods
* Changed NativeViews to use MDXpy in tests. 

